### PR TITLE
Add modern callbacks for class binded functions

### DIFF
--- a/src/core/core.h
+++ b/src/core/core.h
@@ -22,9 +22,9 @@ enum class Poll : uint8_t {
 };
 
 class Core : public Http {
-    typedef void (*CallbackRaw)(Text response);
-    typedef void (*CallbackResult)(gson::Entry& entry);
-    typedef void (*CallbackUpdate)(Update& upd);
+    typedef std::function<void(Text response)> CallbackRaw;
+    typedef std::function<void(gson::Entry& entry)> CallbackResult;
+    typedef std::function<void(Update& upd)> CallbackUpdate;
 
    public:
     // разрешение и запрет типов обновлений


### PR DESCRIPTION
При первоначальной проверке не взлетело, потому что vscode по какой-то неизвестной причине отказывался пересобирать библиотеку бота и сыпал ошибками. Проверил на другом остройстве с чистой IDE установил все либы заново - все нормально компилируется и дает удобный интерфейс для бинда коллбэков также как это реализовано в библиотеках вебсерверов итд

```cpp
#include <Arduino.h>
#include <FastBot2.h>

void outClassTgCallback(fb::Update &u)
{
}

class MyBot
{
private:
    FastBot2    *_bot;

    void inClassUpdateCb(fb::Update &u)
    {
    }
public:
    MyBot(FastBot2 *bot): _bot(bot) { }

    void begin()
    {
        _bot->attachUpdate(std::bind(&MyBot::inClassUpdateCb, this, std::placeholders::_1));
        _bot->attachUpdate(outClassTgCallback);
    }

    void loop()
    {
        _bot->tick();
    }
};

auto tgBot = new FastBot2();
auto myBot = new MyBot(tgBot);

void setup() {
    myBot->begin();
}

void loop() {
    myBot->loop();
}
```